### PR TITLE
make BeltProcessingBehavior.isBlocked more intuitive

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/belt/BeltProcessingBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/belt/BeltProcessingBehaviour.java
@@ -7,7 +7,9 @@ import com.simibubi.create.foundation.tileEntity.TileEntityBehaviour;
 import com.simibubi.create.foundation.tileEntity.behaviour.BehaviourType;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
 /**
@@ -46,8 +48,7 @@ public class BeltProcessingBehaviour extends TileEntityBehaviour {
 		BlockState blockState = world.getBlockState(processingSpace.above());
 		if (AbstractFunnelBlock.isFunnel(blockState))
 			return false;
-		return !blockState.getCollisionShape(world, processingSpace.above())
-			.isEmpty();
+		return Block.isFaceFull(blockState.getCollisionShape(world, processingSpace.above()).getFaceShape(Direction.DOWN), Direction.DOWN);
 	}
 
 	@Override


### PR DESCRIPTION
# Summary
Allow presser, spout, etc. to process item stacks below the tile entity, even when there is a block with collision box between them.
Instead, if a block's collision box's bottom-projected shape completely fills the shape, block processing.

# Expected result
![2022-03-12_03 42 32](https://user-images.githubusercontent.com/76568223/157942349-da88ca22-a073-4fc8-a908-2c97fc268b29.png)
This should allow the processing.

![2022-03-12_04 35 54](https://user-images.githubusercontent.com/76568223/157943158-03401dfa-bfff-4cd9-95a6-26c9ba7eda9c.png)
This should not allow the processing.

