### PR TITLE
Fix basin inventory interaction bug

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/processing/BasinBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/BasinBlock.java
@@ -136,11 +136,8 @@ public class BasinBlock extends Block implements ITE<BasinTileEntity>, IWrenchab
 		ItemEntity itemEntity = (ItemEntity) entityIn;
 		withTileEntityDo(worldIn, entityIn.blockPosition(), te -> {
 
-			// Tossed items bypass the quarter-stack limit
-			te.inputInventory.withMaxStackSize(64);
 			ItemStack insertItem = ItemHandlerHelper.insertItem(te.inputInventory, itemEntity.getItem()
 				.copy(), false);
-			te.inputInventory.withMaxStackSize(16);
 
 			if (insertItem.isEmpty()) {
 				itemEntity.discard();

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/BasinInventory.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/BasinInventory.java
@@ -10,7 +10,7 @@ public class BasinInventory extends SmartInventory {
 	private BasinTileEntity te;
 
 	public BasinInventory(int slots, BasinTileEntity te) {
-		super(slots, te, 16, true);
+		super(slots, te);
 		this.te = te;
 	}
 

--- a/src/main/java/com/simibubi/create/lib/transfer/item/StorageItemHandler.java
+++ b/src/main/java/com/simibubi/create/lib/transfer/item/StorageItemHandler.java
@@ -51,7 +51,7 @@ public class StorageItemHandler implements Storage<ItemVariant> {
 	public long extract(ItemVariant resource, long maxAmount, TransactionContext transaction) {
 		ItemStack toExtract = resource.toStack((int) maxAmount);
 		ItemStack extracted = ItemHandlerHelper.extract(handler, toExtract, true);
-		transaction.addOuterCloseCallback(result -> {
+		transaction.addCloseCallback((transaction1, result) -> {
 			if (result.wasCommitted()) {
 				ItemHandlerHelper.extract(handler, toExtract, false);
 			}
@@ -100,11 +100,11 @@ public class StorageItemHandler implements Storage<ItemVariant> {
 			ItemStack extracted = owner.extractItem(slotIndex, (int) maxAmount, true);
 			if (extracted.is(resource.getItem())) {
 				actual = extracted.getCount();
-				transaction.addOuterCloseCallback(result -> {
+				transaction.addCloseCallback(((transaction1, result) -> {
 					if (result.wasCommitted()) {
 						owner.extractItem(slotIndex, (int) maxAmount, false);
 					}
-				});
+				}));
 			}
 			return actual;
 		}


### PR DESCRIPTION
# Summary
Basin inventory has some bugs when interacting non-create storages.

# Bugs
- Item extraction from basin always removing extracted item even when extraction is aborted.
- Item insertion into basin, when the item variant is not present in the basin, accepts more than it can hold. (though item is not inserted, causes item deletion)

# Causes
- StorageItemHandler.extract has callback when transaction is closed, where it should check for its own transaction but it checks outer transaction. Changed `addOuterCloseCallback` to `addCloseCallback`.
- Each item insertion simulation per slot is run independently, and basin inventory does not allow same item in other slots, which makes only first insertion succeeds but all simulated insertion results are applied to input stack count. There is no easy and direct solution to this bug, but naive solution would be removing basin's max slot size limitation.